### PR TITLE
Adds a `/version` endpoint

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -10,8 +10,7 @@ const poweredByHandler = (_, res, next): void => {
   next();
 };
 
-const fallbackHandler = (req, res, next): Express.Response => {
-  console.dir(req.baseUrl);
+const fallbackHandler = (req, res, next): Express.Response | void => {
   // Root URL path
   if (req.baseUrl === '') {
     res.status(200);
@@ -34,19 +33,23 @@ const fallbackHandler = (req, res, next): Express.Response => {
   return next(err);
 };
 
-const notFoundHandler = (err, _, res, next): Express.Response => {
-  if (err.status !== 404) {
-    return next(err);
+const genericErrorHandler = (
+  err: CustomError,
+  _,
+  res,
+  next
+): Express.Response | void => {
+  // This will never be called but to satisfy Typescript, we make use of it.
+  if (!err) next();
+
+  if (err.status === 404) {
+    res.status(404);
+    return res.send({
+      status: 404,
+      error: err.message || "These are not the snakes you're looking for",
+    });
   }
 
-  res.status(404);
-  return res.send({
-    status: 404,
-    error: err.message || "These are not the snakes you're looking for",
-  });
-};
-
-const genericErrorHandler = (err, _, res): Express.Response => {
   const { status } = err;
 
   res.status(status);
@@ -56,9 +59,4 @@ const genericErrorHandler = (err, _, res): Express.Response => {
   });
 };
 
-export {
-  fallbackHandler,
-  notFoundHandler,
-  genericErrorHandler,
-  poweredByHandler,
-};
+export { fallbackHandler, genericErrorHandler, poweredByHandler };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import express from 'express';
 import logger from 'morgan';
 import {
   fallbackHandler,
-  notFoundHandler,
   genericErrorHandler,
   poweredByHandler,
 } from './handlers';
@@ -62,10 +61,14 @@ app.post('/ping', (request, response) => {
   return response.json({});
 });
 
+app.get('/version', (_, response) => {
+  response.status(200);
+  return response.send(process.env.VERSION || 'undefined');
+});
+
 // --- SNAKE LOGIC GOES ABOVE THIS LINE ---
 
 app.use('*', fallbackHandler);
-app.use(notFoundHandler);
 app.use(genericErrorHandler);
 
 app.listen(app.get('port'), () => {


### PR DESCRIPTION
Also refines the handlers a bit to fix an issue with the `/` root endpoint. This can be merged in, but won't be useful until I finish #30 where I'm doing to provision the Droplets and run them with the version as an env var. Currently this will display `undefined` indefinitely until said work is done.