### PR TITLE
Provision DO Droplet with Terraform on merge into master

### DIFF
--- a/.github/workflows/build-and-deploy-container.yml
+++ b/.github/workflows/build-and-deploy-container.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - terraform-do-droplet-on-merge
 
 jobs:
   build_deploy:

--- a/.github/workflows/build-and-deploy-container.yml
+++ b/.github/workflows/build-and-deploy-container.yml
@@ -5,9 +5,10 @@ on:
   push:
     branches:
       - master
+      - terraform-do-droplet-on-merge
 
 jobs:
-  build:
+  build_deploy:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -27,28 +28,28 @@ jobs:
         with:
           accessToken: ${{ secrets.GITHUB_TOKEN }}
           imageTag: "latest"
-
-  deploy:
-    runs-on: ubuntu-18.04
-    needs: build
-    steps:
-      - uses: actions/checkout@v2
-      - name: List all Droplets
-        uses: digitalocean/action-doctl@master
-        env:
-          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_API_KEY }}
+      - name: Terraform Init
+        uses: hashicorp/terraform-github-actions@master
         with:
-          args: compute droplet list 'echosec-bounty-snake' > $GITHUB_WORKSPACE/droplets_list.json
-      - name: Set the Droplet ID var
-        id: droplet_id
-        run: |
-          DROPLET_ID=$(cat $GITHUB_WORKSPACE/droplets_list.json | jq --raw-output ".[].id")
-          echo ::set-output name=droplet_id::$DROPLET_ID
-          echo "Droplet ID: " $DROPLET_ID
-      - name: Rebuild DO Droplet to pull latest image
+          tf_actions_version: 0.12.21
+          tf_actions_subcommand: 'init'
+          tf_actions_working_dir: './terraform'
+          tf_actions_comment: false
+          args: '-backend-config="token=${{ secrets.TF_API_TOKEN }}"'
+      - name: Terraform Plan
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: 0.12.21
+          tf_actions_subcommand: 'plan'
+          tf_actions_working_dir: './terraform'
+          tf_actions_comment: false
+          args: '-var="image_tag=${{ steps.vars.outputs.image_tag }}"'
+      - name: Terraform Apply
         if: success()
-        uses: digitalocean/action-doctl@master
-        env:
-          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_API_KEY }}
+        uses: hashicorp/terraform-github-actions@master
         with:
-          args: compute droplet-action rebuild ${{ steps.droplet_id.outputs.droplet_id }} --image docker-18-04 --verbose
+          tf_actions_version: 0.12.21
+          tf_actions_subcommand: 'apply'
+          tf_actions_working_dir: './terraform'
+          tf_actions_comment: false
+          args: '-var="image_tag=${{ steps.vars.outputs.image_tag }}"'

--- a/.github/workflows/build-and-deploy-container.yml
+++ b/.github/workflows/build-and-deploy-container.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           accessToken: ${{ secrets.GITHUB_TOKEN }}
           imageTag: "latest"
+      - name: Create tfvars file with variables
+        run: |
+          echo "image_tag = \"${{ steps.vars.outputs.image_tag }}\"" > terraform/terraform.auto.tfvars
       - name: Terraform Init
         uses: hashicorp/terraform-github-actions@master
         with:
@@ -43,7 +46,6 @@ jobs:
           tf_actions_subcommand: 'plan'
           tf_actions_working_dir: './terraform'
           tf_actions_comment: false
-          args: '-var="image_tag=${{ steps.vars.outputs.image_tag }}"'
       - name: Terraform Apply
         if: success()
         uses: hashicorp/terraform-github-actions@master
@@ -52,4 +54,3 @@ jobs:
           tf_actions_subcommand: 'apply'
           tf_actions_working_dir: './terraform'
           tf_actions_comment: false
-          args: '-var="image_tag=${{ steps.vars.outputs.image_tag }}"'

--- a/.gitignore
+++ b/.gitignore
@@ -604,6 +604,7 @@ MigrationBackup/
 **/.terraform/*
 **/.terraformrc
 **/.tfvars
+**/*.tfvars
 
 # .tfstate files
 *.tfstate

--- a/terraform/check_health.sh
+++ b/terraform/check_health.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Borrowed from from https://github.com/nicholasjackson/terraform-digitalocean-lifecycle
+
+# Simple script to check the health of a created droplet
+fail_count=1
+
+while true
+do
+  response=$(curl --write-out %{http_code} --silent --output /dev/null $1)
+
+  if [ $response -eq 200 ] ; then
+    echo "$(date -u) Server available"
+    exit 0
+  else
+    if [ $fail_count -eq 11 ]; then
+      echo "$(date -u) Server unavailable"
+      exit 2
+    else
+      echo "$(date -u) Attempt ${fail_count}/10: Server not yet available"
+      sleep 3
+      fail_count=$[$fail_count +1]
+    fi
+  fi
+done

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -27,9 +27,14 @@ resource "digitalocean_droplet" "bounty_snake_droplet" {
     #cloud-config
     runcmd:
       - docker login docker.pkg.github.com -u ${var.github_username} -p ${var.github_token}
-      - docker pull docker.pkg.github.com/echosec/bounty-snake-2020/bounty-snake-2020:latest
-      - docker run -t -d -p 80:5000 docker.pkg.github.com/echosec/bounty-snake-2020/bounty-snake-2020:latest
+      - docker pull docker.pkg.github.com/echosec/bounty-snake-2020/bounty-snake-2020:${var.image_tag}
+      - docker run -t -d -p 80:5000 --env VERSION=${var.image_tag} --restart=unless-stopped docker.pkg.github.com/echosec/bounty-snake-2020/bounty-snake-2020:${var.image_tag}
     EOM
+
+  # https://www.hashicorp.com/blog/zero-downtime-updates-with-terraform/
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "digitalocean_firewall" "bounty_snake_firewall" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -31,9 +31,12 @@ resource "digitalocean_droplet" "bounty_snake_droplet" {
       - docker run -t -d -p 80:5000 --env VERSION=${var.image_tag} --restart=unless-stopped docker.pkg.github.com/echosec/bounty-snake-2020/bounty-snake-2020:${var.image_tag}
     EOM
 
-  # https://www.hashicorp.com/blog/zero-downtime-updates-with-terraform/
   lifecycle {
     create_before_destroy = true
+  }
+
+  provisioner "local-exec" {
+    command = "./check_health.sh ${self.ipv4_address}"
   }
 }
 
@@ -82,4 +85,8 @@ resource "digitalocean_firewall" "bounty_snake_firewall" {
 resource "digitalocean_floating_ip_assignment" "bounty_snake_ip" {
   ip_address = var.floating_ip
   droplet_id = digitalocean_droplet.bounty_snake_droplet.id
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -13,6 +13,11 @@ variable "github_token" {
   type        = string
 }
 
+variable "image_tag" {
+  description = "The 7-char SHA hash used for the Docker tag"
+  type        = string
+}
+
 variable "domain_name" {
   description = "Domain name to point to the IP of our hosted DigitalOcean droplet"
   type        = string


### PR DESCRIPTION
Uses GH Actions and Terraform to provision the droplet upon merge instead of the hacky way we were doing it before. This helps us achieve zero-downtime deploys using Terraform thanks to this post https://www.hashicorp.com/blog/zero-downtime-updates-with-terraform/