### PR TITLE
Refactor function to eliminate initialization of new Pathfinder class

### DIFF
--- a/src/__tests__/behaviours/chaseTail.test.ts
+++ b/src/__tests__/behaviours/chaseTail.test.ts
@@ -1,16 +1,19 @@
 import { ISnake, IBoard, Directions } from '../../Types';
 import { chaseTail } from '../../behaviours/chaseTail';
 import { gameState } from '../fixtures/Gamestate';
+import Pathfinder from '../../Pathfinder';
 
 describe('Chase tail behaviour', () => {
   test('should return a direction for the shortest path to our own tail', () => {
     // Arrange
     const board: IBoard = gameState.board;
+    const snakes: ISnake[] = gameState.board.snakes;
+    const PF: Pathfinder = new Pathfinder(board, snakes);
     const us: ISnake = gameState.board.snakes[0];
     const expectedDirection: string = Directions.LEFT;
 
     // Act
-    const actualDirection = chaseTail(board, us);
+    const actualDirection = chaseTail(PF, us);
 
     expect(actualDirection).toBe(expectedDirection);
   });

--- a/src/behaviours/chaseTail.ts
+++ b/src/behaviours/chaseTail.ts
@@ -14,4 +14,3 @@ export const chaseTail = (PF: Pathfinder, us: ISnake): Directions => {
 };
 
 export default chaseTail;
-

--- a/src/behaviours/chaseTail.ts
+++ b/src/behaviours/chaseTail.ts
@@ -2,7 +2,7 @@ import { ISnake, ICoordinate, Directions } from '../Types';
 import Pathfinder from '../Pathfinder';
 
 /**
- * @param {IBoard} board - the board state
+ * @param {Pathfinder} PF - Pathfinder class initialized with game state
  * @param {ISnake} us - our snake
  * @returns {Directions} returns the next direction
  */

--- a/src/behaviours/chaseTail.ts
+++ b/src/behaviours/chaseTail.ts
@@ -1,4 +1,4 @@
-import { ISnake, IBoard, ICoordinate, Directions } from '../Types';
+import { ISnake, ICoordinate, Directions } from '../Types';
 import Pathfinder from '../Pathfinder';
 
 /**
@@ -6,10 +6,7 @@ import Pathfinder from '../Pathfinder';
  * @param {ISnake} us - our snake
  * @returns {Directions} returns the next direction
  */
-export const chaseTail = (board: IBoard, us: ISnake): Directions => {
-  const snakes: ISnake[] = board.snakes;
-  const PF = new Pathfinder(board, snakes);
-
+export const chaseTail = (PF: Pathfinder, us: ISnake): Directions => {
   const head: ICoordinate = us.body[0];
   const tail: ICoordinate = us.body[us.body.length - 1];
 
@@ -17,3 +14,4 @@ export const chaseTail = (board: IBoard, us: ISnake): Directions => {
 };
 
 export default chaseTail;
+


### PR DESCRIPTION
To stop us from passing around the board and re-initializing the Pathfinder class in each behaviour, I have refactored the chaseTail function to accept an initialized Pathfinder class.