### PR TITLE
Adds the monitoring agent to the Droplet

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -16,14 +16,15 @@ provider "digitalocean" {
 }
 
 resource "digitalocean_droplet" "bounty_snake_droplet" {
-  image     = "docker-18-04"
-  name      = "echosec-bounty-snake"
-  region    = "sfo2"
-  size      = "s-2vcpu-4gb"
-  ssh_keys  = [
+  image       = "docker-18-04"
+  name        = "echosec-bounty-snake"
+  region      = "sfo2"
+  size        = "s-2vcpu-4gb"
+  monitoring  = true
+  ssh_keys    = [
     25059594 # brandonb@echosec.net
   ]
-  user_data = <<EOM
+  user_data   = <<EOM
     #cloud-config
     runcmd:
       - docker login docker.pkg.github.com -u ${var.github_username} -p ${var.github_token}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -78,6 +78,12 @@ resource "digitalocean_firewall" "bounty_snake_firewall" {
 
   outbound_rule {
     protocol              = "tcp"
+    port_range            = "80"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "tcp"
     port_range            = "443"
     destination_addresses = ["0.0.0.0/0", "::/0"]
   }


### PR DESCRIPTION
This config change will add the [monitoring agent](https://www.digitalocean.com/docs/monitoring/) so we can get some metrics on the running Droplet. This is surprisingly not enabled by default.. thought with this we can setup some [alerts and policies](https://www.digitalocean.com/docs/monitoring/how-to/set-up-alerts/).

Running `terraform plan` yields this change for the `monitoring` attribute:
```terraform
      ~ monitoring           = false -> true # forces replacement
```