### PR TITLE
Adds a Droplet with redis-server in Terraform

### DIFF
--- a/terraform/check_health.sh
+++ b/terraform/check_health.sh
@@ -12,11 +12,11 @@ do
     echo "$(date -u) Server available"
     exit 0
   else
-    if [ $fail_count -eq 11 ]; then
+    if [ $fail_count -eq 21 ]; then
       echo "$(date -u) Server unavailable"
       exit 2
     else
-      echo "$(date -u) Attempt ${fail_count}/10: Server not yet available"
+      echo "$(date -u) Attempt ${fail_count}/20: Server not yet available"
       sleep 10
       fail_count=$[$fail_count +1]
     fi

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -97,6 +97,14 @@ resource "digitalocean_firewall" "bounty_snake_firewall" {
     source_addresses = ["0.0.0.0/0", "::/0"]
   }
 
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "443"
+    source_droplet_ids = [
+      digitalocean_droplet.bounty_snake_droplet.id
+    ]
+  }
+
   outbound_rule {
     protocol              = "tcp"
     port_range            = "53"
@@ -119,5 +127,14 @@ resource "digitalocean_firewall" "bounty_snake_firewall" {
     protocol              = "tcp"
     port_range            = "443"
     destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "443"
+    destination_droplet_ids = [
+      digitalocean_droplet.bounty_snake_redis.id
+    ]
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -61,10 +61,7 @@ resource "digitalocean_droplet" "bounty_snake_redis" {
 resource "digitalocean_firewall" "bounty_snake_firewall" {
   name = "bounty-snake-firewall"
 
-  droplet_ids = [
-    digitalocean_droplet.bounty_snake_droplet.id,
-    digitalocean_droplet.bounty_snake_redis.id
-  ]
+  droplet_ids = [digitalocean_droplet.bounty_snake_droplet.id]
 
   inbound_rule {
     protocol         = "tcp"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -27,7 +27,7 @@ resource "digitalocean_droplet" "bounty_snake_droplet" {
     runcmd:
       - docker login docker.pkg.github.com -u ${var.github_username} -p ${var.github_token}
       - docker pull docker.pkg.github.com/echosec/bounty-snake-2020/bounty-snake-2020:${var.image_tag}
-      - docker run -t -d -p 80:5000 --env VERSION=${var.image_tag} --env REDIS_HOST=${digitalocean_droplet.bounty_snake_redis.ipv4_address_private} --restart=unless-stopped docker.pkg.github.com/echosec/bounty-snake-2020/bounty-snake-2020:${var.image_tag}
+      - docker run -t -d -p 80:5000 --env VERSION=${var.image_tag} --env REDIS_HOST=${digitalocean_droplet.bounty_snake_redis.ipv4_address} --restart=unless-stopped docker.pkg.github.com/echosec/bounty-snake-2020/bounty-snake-2020:${var.image_tag}
     EOM
 
   lifecycle {
@@ -99,7 +99,7 @@ resource "digitalocean_firewall" "bounty_snake_firewall" {
 
   inbound_rule {
     protocol         = "tcp"
-    port_range       = "443"
+    port_range       = "6379"
     source_droplet_ids = [
       digitalocean_droplet.bounty_snake_droplet.id
     ]
@@ -132,7 +132,7 @@ resource "digitalocean_firewall" "bounty_snake_firewall" {
 
   outbound_rule {
     protocol              = "tcp"
-    port_range            = "443"
+    port_range            = "6379"
     destination_droplet_ids = [
       digitalocean_droplet.bounty_snake_redis.id
     ]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -45,14 +45,14 @@ resource "digitalocean_droplet" "bounty_snake_redis" {
   region              = "sfo2"
   size                = "s-1vcpu-1gb"
   monitoring          = true
-  private_networking  = true
   ssh_keys            = var.ssh_key_ids
   user_data           = <<EOM
     #cloud-config
     runcmd:
-      - sudo apt update -y
-      - sudo apt install -y redis-server
+      - sudo apt-get update -y
+      - sudo apt-get install -y redis-server
       - sed -i -e '/supervised/s|no|systemd|' /etc/redis/redis.conf
+      - sed -i -e '/bind 127.0.0.1 ::1/s|127.0.0.1 ::1|0.0.0.0|' /etc/redis/redis.conf
       - sudo systemctl restart redis.service
     EOM
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -27,7 +27,7 @@ resource "digitalocean_droplet" "bounty_snake_droplet" {
     runcmd:
       - docker login docker.pkg.github.com -u ${var.github_username} -p ${var.github_token}
       - docker pull docker.pkg.github.com/echosec/bounty-snake-2020/bounty-snake-2020:${var.image_tag}
-      - docker run -t -d -p 80:5000 --env VERSION=${var.image_tag} --restart=unless-stopped docker.pkg.github.com/echosec/bounty-snake-2020/bounty-snake-2020:${var.image_tag}
+      - docker run -t -d -p 80:5000 --env VERSION=${var.image_tag} --env REDIS_HOST=${digitalocean_droplet.bounty_snake_redis.ipv4_address_private} --restart=unless-stopped docker.pkg.github.com/echosec/bounty-snake-2020/bounty-snake-2020:${var.image_tag}
     EOM
 
   lifecycle {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -21,9 +21,7 @@ resource "digitalocean_droplet" "bounty_snake_droplet" {
   region      = "sfo2"
   size        = "s-2vcpu-4gb"
   monitoring  = true
-  ssh_keys    = [
-    25059594 # brandonb@echosec.net
-  ]
+  ssh_keys    = var.ssh_key_ids
   user_data   = <<EOM
     #cloud-config
     runcmd:
@@ -41,10 +39,32 @@ resource "digitalocean_droplet" "bounty_snake_droplet" {
   }
 }
 
+resource "digitalocean_droplet" "bounty_snake_redis" {
+  image       = "ubuntu-18-04-x64"
+  name        = "echosec-bounty-snake-redis"
+  region      = "sfo2"
+  size        = "s-1vcpu-1gb"
+  monitoring  = true
+  ssh_keys    = var.ssh_key_ids
+  user_data   = <<EOM
+    #cloud-config
+    runcmd:
+      - sudo apt update -y
+      - sudo apt install -y redis-server
+    EOM
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 resource "digitalocean_firewall" "bounty_snake_firewall" {
   name = "bounty-snake-firewall"
 
-  droplet_ids = [digitalocean_droplet.bounty_snake_droplet.id]
+  droplet_ids = [
+    digitalocean_droplet.bounty_snake_droplet.id,
+    digitalocean_droplet.bounty_snake_redis.id
+  ]
 
   inbound_rule {
     protocol         = "tcp"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -29,3 +29,11 @@ variable "floating_ip" {
   type        = string
   default     = "167.99.25.113"
 }
+
+variable "ssh_key_ids" {
+  description = "A list of SSH key IDs from DigitalOcean to allow SSH access to a droplet"
+  type        = list(string)
+  default     = [
+    25059594 # brandonb@echosec.net
+  ]
+}


### PR DESCRIPTION
This config adds a DO Droplet with a running redis server. I've already ran the `terraform apply` for this so it just needs to be merged in and verified that it can be accessed by the Private IP from the Bounty Snake Droplet.