### PR TITLE
Fix bug causing head to head collisions

### DIFF
--- a/src/behaviours/seekSafestFood.ts
+++ b/src/behaviours/seekSafestFood.ts
@@ -79,8 +79,8 @@ export const seekSafestFood = (
     const head: ICoordinate = us.body[0];
     const { food: foodArray } = board;
 
-    let pathToSafestFood: Matrix;
-    let safestFood: ICoordinate;
+    let pathToSafestFood: Matrix = [];
+    let safestFood: ICoordinate = null;
     // For each food item we check:
     // 1. Are we closer than any other snake.
     // 2. After we eat the food do we have a path to another snakes tail (escape route)
@@ -91,7 +91,8 @@ export const seekSafestFood = (
       const noDeadEnds = canWeGetAway(pathToSnack, us, board);
 
       if (
-        (!pathToSafestFood || pathToSnack.length < pathToSafestFood.length) &&
+        (pathToSafestFood.length === 0 ||
+          pathToSnack.length < pathToSafestFood.length) &&
         winnerWinnerChickenDinner &&
         noDeadEnds
       ) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -85,7 +85,7 @@ export function firstToFood(
   for (const snek of otherSneks) {
     const enemyPath: Matrix = PF.getFullPath(snek.body[0], food);
 
-    if (enemyPath && enemyPath.length < ourPath.length) {
+    if (enemyPath && enemyPath.length <= ourPath.length) {
       return false;
     }
   }


### PR DESCRIPTION
Realized the helper function for finding the safest food wasn't that safe; it returned true if we were tied for the closest to the food, causing head on collisions.